### PR TITLE
102 dropbox receipt

### DIFF
--- a/cogs/DropBox.py
+++ b/cogs/DropBox.py
@@ -380,17 +380,17 @@ class DropBox(BaseCog):
 
     @dropbox.command()
     @commands.guild_only()
-    async def set_receipt(self, ctx, channel: discord.TextChannel, receipt:bool):
+    async def set_receipt(self, ctx, source_channel: discord.TextChannel, receipt_setting:bool):
         """
         set whether or not this dropbox channel should include a dm that sends the message author a copy of their message
         """
-        if channel.id in self.dropboxes[ctx.guild.id]:
-            drop = self.dropboxes[ctx.guild.id][channel.id]
-            drop.sendreceipt = receipt
+        if source_channel.id in self.dropboxes[ctx.guild.id]:
+            drop = self.dropboxes[ctx.guild.id][source_channel.id]
+            drop.sendreceipt = receipt_setting
             drop.save()
-            msg = Lang.get_locale_string('dropbox/receipt_set_false', ctx, channel=channel.mention)
-            if receipt:
-                msg = Lang.get_locale_string('dropbox/receipt_set_true', ctx, channel=channel.mention)
+            msg = Lang.get_locale_string('dropbox/receipt_set_false', ctx, channel=source_channel.mention)
+            if receipt_setting:
+                msg = Lang.get_locale_string('dropbox/receipt_set_true', ctx, channel=source_channel.mention)
             await ctx.send(msg)
 
     @commands.Cog.listener()

--- a/cogs/DropBox.py
+++ b/cogs/DropBox.py
@@ -237,10 +237,6 @@ class DropBox(BaseCog):
             # ignore delete failure. we'll try again next time
             await Utils.handle_exception('dropbox clean_message failure', self.bot, e)
 
-    @commands.Cog.listener()
-    async def on_guild_join(self, guild):
-        self.init_guild(guild.id)
-
     @commands.group(name="dropbox", invoke_without_command=True)
     @commands.guild_only()
     async def dropbox(self, ctx):
@@ -371,16 +367,16 @@ class DropBox(BaseCog):
         Set the lifespan for response messages in the channel
 
         Also applies to any non-mod messages, so the delay time must be greater than the initial wait for message drops.
-        delay: Time until responses expire (milliseconds)
+        delay: Time until responses expire (seconds)
         """
         if channel.id in self.dropboxes[ctx.guild.id]:
             drop = self.dropboxes[ctx.guild.id][channel.id]
             drop.deletedelayms = int(delay * 1000)
             drop.save()
             t = Utils.to_pretty_time(delay)
-            await ctx.send(f'Confirmation messages in dropbox channel {channel.mention} will be deleted after {t}')
+            await ctx.send(Lang.get_locale_string('dropbox/set_delay_success', ctx, channel=channel.mention, time=t))
         else:
-            await ctx.send(f'Failed to set dropbox delete delay time in {channel.mention}')
+            await ctx.send(Lang.get_locale_string('dropbox/set_delay_fail', ctx, channel=channel.mention))
 
     @dropbox.command()
     @commands.guild_only()

--- a/cogs/DropBox.py
+++ b/cogs/DropBox.py
@@ -204,13 +204,13 @@ class DropBox(BaseCog):
                             
                     last_page = f'```{pages[-1]}```' if page_count == 1 else f"**{page_count} of {page_count}**\n```{pages[-1]}```"
                     await dm_channel.send(last_page)
-
-                embed.add_field(name="receipt status", value="sent")
-                # this is used if drop first before dms to add status to embed
-                await last_drop_message.edit(embed=embed)
+                if delivery_success:
+                    embed.add_field(name="receipt status", value="sent")
+                    # this is used if drop first before dms to add status to embed
+                    await last_drop_message.edit(embed=embed)
         except Exception as e:
             Logging.info("Dropbox DM receipt failed, not an issue so ignoring exception and giving up")
-            if drop.sendreceipt:
+            if drop.sendreceipt and delivery_success:
                 embed.add_field(name="receipt status", value="failed")
                 # this is used if drop first before dms to add status to embed
                 await last_drop_message.edit(embed=embed)

--- a/db_migrations/db_migrate_0008.py
+++ b/db_migrations/db_migrate_0008.py
@@ -1,0 +1,18 @@
+from playhouse.migrate import *
+from utils import Configuration
+
+connection = MySQLDatabase(Configuration.get_var("DATABASE_NAME"),
+                           user=Configuration.get_var("DATABASE_USER"),
+                           password=Configuration.get_var("DATABASE_PASS"),
+                           host=Configuration.get_var("DATABASE_HOST"),
+                           port=Configuration.get_var("DATABASE_PORT"),
+                           use_unicode=True,
+                           charset="utf8mb4")
+
+migrator = MySQLMigrator(connection)
+sendreceipt = BooleanField(default=False)
+
+# Run the migration, specifying the database table, field name and field.
+migrate(
+    migrator.add_column('dropboxchannel', 'sendreceipt', sendreceipt),
+)

--- a/lang_keys.yaml
+++ b/lang_keys.yaml
@@ -133,6 +133,8 @@ dropbox:
   not_removed:
   channel_not_found:
   override_confirmation:
+  set_delay_success:
+  set_delay_fail:
   msg_delivered:
   msg_not_delivered:
   msg_receipt:

--- a/lang_keys.yaml
+++ b/lang_keys.yaml
@@ -135,6 +135,9 @@ dropbox:
   override_confirmation:
   msg_delivered:
   msg_not_delivered:
+  msg_receipt:
+  receipt_set_true:
+  receipt_set_false:
 autoresponder:
   mod_action_header:
   mod_action_warning:

--- a/lang_keys.yaml
+++ b/lang_keys.yaml
@@ -137,6 +137,7 @@ dropbox:
   set_delay_fail:
   msg_delivered:
   msg_not_delivered:
+  msg_blank:
   attachment_fail:
   msg_receipt:
   receipt_set_true:

--- a/lang_keys.yaml
+++ b/lang_keys.yaml
@@ -137,9 +137,12 @@ dropbox:
   set_delay_fail:
   msg_delivered:
   msg_not_delivered:
+  attachment_fail:
   msg_receipt:
   receipt_set_true:
   receipt_set_false:
+  receipt_attachment_singular:
+  receipt_attachment_plural:
 autoresponder:
   mod_action_header:
   mod_action_warning:

--- a/langs/en_US.yaml
+++ b/langs/en_US.yaml
@@ -252,8 +252,8 @@ dropbox:
   msg_delivered: Your message was delivered, {author}
   msg_not_delivered: Your message was **not** delivered, {author}. Please try again, or contact a moderator
   msg_receipt: Here's a copy of the dropbox message you sent in {channel}
-  receipt_set_true: receipt set. authors will be DM'd a copy of their message in {channel}.
-  receipt_set_false: receipt set. authors won't be dmed for their messages in {channel}.
+  receipt_set_true: receipt set. authors will be DMed a copy of their message in {channel}.
+  receipt_set_false: receipt set. authors won't be DMed for their messages in {channel}.
 autoresponder:
   mod_action_header: Moderator actions
   mod_action_warning: Moderator action flag will be ignored if response channel is not set. Use `!autoresponder setchannel`

--- a/langs/en_US.yaml
+++ b/langs/en_US.yaml
@@ -252,6 +252,8 @@ dropbox:
   msg_delivered: Your message was delivered, {author}
   msg_not_delivered: Your message was **not** delivered, {author}. Please try again, or contact a moderator
   msg_receipt: Here's a copy of the dropbox message you sent in {channel}
+  set_delay_success: Confirmation messages in dropbox channel {channel} will be deleted after {time}
+  set_delay_fail: Failed to set dropbox delete delay time in {channel}
   receipt_set_true: receipt set. authors will be DMed a copy of their message in {channel}.
   receipt_set_false: receipt set. authors won't be DMed for their messages in {channel}.
 autoresponder:

--- a/langs/en_US.yaml
+++ b/langs/en_US.yaml
@@ -249,13 +249,16 @@ dropbox:
   not_removed: There's no dropbox for channel {source}
   channel_not_found: Sorry, I couldn't find a channel with id {channel_id}
   override_confirmation: The channel {source} already delivers messages to {old_target}; do you want to change the target to {new_target}?
-  msg_delivered: Your message was delivered, {author}
-  msg_not_delivered: Your message was **not** delivered, {author}. Please try again, or contact a moderator
-  msg_receipt: Here's a copy of the dropbox message you sent in {channel}
   set_delay_success: Confirmation messages in dropbox channel {channel} will be deleted after {time}
   set_delay_fail: Failed to set dropbox delete delay time in {channel}
+  msg_delivered: "{author} Your message was delivered"
+  msg_not_delivered: "{author} Your message was **not** delivered. Please try again, or contact a moderator"
+  attachment_fail: Attachment from {author} failed. Censored or deleted by member?
+  msg_receipt: "Here's a copy of the message you sent in {channel}:"
   receipt_set_true: receipt set. authors will be DMed a copy of their message in {channel}.
   receipt_set_false: receipt set. authors won't be DMed for their messages in {channel}.
+  receipt_attachment_singular: "{number} attached file: {attachments}"
+  receipt_attachment_plural: "{number} attached files: {attachments}"
 autoresponder:
   mod_action_header: Moderator actions
   mod_action_warning: Moderator action flag will be ignored if response channel is not set. Use `!autoresponder setchannel`

--- a/langs/en_US.yaml
+++ b/langs/en_US.yaml
@@ -251,6 +251,9 @@ dropbox:
   override_confirmation: The channel {source} already delivers messages to {old_target}; do you want to change the target to {new_target}?
   msg_delivered: Your message was delivered, {author}
   msg_not_delivered: Your message was **not** delivered, {author}. Please try again, or contact a moderator
+  msg_receipt: Here's a copy of the dropbox message you sent in {channel}
+  receipt_set_true: receipt set. authors will be DM'd a copy of their message in {channel}.
+  receipt_set_false: receipt set. authors won't be dmed for their messages in {channel}.
 autoresponder:
   mod_action_header: Moderator actions
   mod_action_warning: Moderator action flag will be ignored if response channel is not set. Use `!autoresponder setchannel`

--- a/langs/en_US.yaml
+++ b/langs/en_US.yaml
@@ -253,6 +253,7 @@ dropbox:
   set_delay_fail: Failed to set dropbox delete delay time in {channel}
   msg_delivered: "{author} Your message was delivered"
   msg_not_delivered: "{author} Your message was **not** delivered. Please try again, or contact a moderator"
+  msg_blank: I didn't find any text content in the original message
   attachment_fail: Attachment from {author} failed. Censored or deleted by member?
   msg_receipt: "Here's a copy of the message you sent in {channel}:"
   receipt_set_true: receipt set. authors will be DMed a copy of their message in {channel}.

--- a/langs/ja_JP.yaml
+++ b/langs/ja_JP.yaml
@@ -253,6 +253,7 @@ dropbox:
   set_delay_fail: Failed to set dropbox delete delay time in {channel}
   msg_delivered: --jp-- {author} Your message was delivered
   msg_not_delivered: --jp-- {author} Your message was **not** delivered Please try again, or contact a moderator
+  msg_blank: --jp-- I didn't find any text content in the original message
   msg_receipt: --jp-- Here's a copy of the dropbox message you sent in {channel}
   receipt_set_true: --jp-- receipt set. authors will be DMed a copy of their message in {channel}.
   receipt_set_false: --jp-- receipt set. authors won't be DMed for their messages in {channel}.

--- a/langs/ja_JP.yaml
+++ b/langs/ja_JP.yaml
@@ -251,11 +251,13 @@ dropbox:
   override_confirmation: --jp-- The channel {source} already delivers messages to {old_target}; do you want to change the target to {new_target}?
   set_delay_success: Confirmation messages in dropbox channel {channel} will be deleted after {time}
   set_delay_fail: Failed to set dropbox delete delay time in {channel}
-  msg_delivered: --jp-- Your message was delivered, {author}
-  msg_not_delivered: --jp-- Your message was **not** delivered, {author}. Please try again, or contact a moderator
+  msg_delivered: --jp-- {author} Your message was delivered
+  msg_not_delivered: --jp-- {author} Your message was **not** delivered Please try again, or contact a moderator
   msg_receipt: --jp-- Here's a copy of the dropbox message you sent in {channel}
   receipt_set_true: --jp-- receipt set. authors will be DMed a copy of their message in {channel}.
   receipt_set_false: --jp-- receipt set. authors won't be DMed for their messages in {channel}.
+  receipt_attachment_singular: "--jp-- {number} attached file: {attachments}"
+  receipt_attachment_plural: "--jp-- {number} attached files: {attachments}"
 autoresponder:
   mod_action_header: --jp-- Moderator actions
   mod_action_warning: --jp-- Moderator action flag will be ignored if response channel is not set. Use `!autoresponder setchannel`

--- a/langs/ja_JP.yaml
+++ b/langs/ja_JP.yaml
@@ -249,6 +249,8 @@ dropbox:
   not_removed: --jp-- There's no dropbox for channel {source}
   channel_not_found: --jp-- Sorry, I couldn't find a channel with id {channel_id}
   override_confirmation: --jp-- The channel {source} already delivers messages to {old_target}; do you want to change the target to {new_target}?
+  set_delay_success: Confirmation messages in dropbox channel {channel} will be deleted after {time}
+  set_delay_fail: Failed to set dropbox delete delay time in {channel}
   msg_delivered: --jp-- Your message was delivered, {author}
   msg_not_delivered: --jp-- Your message was **not** delivered, {author}. Please try again, or contact a moderator
   msg_receipt: --jp-- Here's a copy of the dropbox message you sent in {channel}

--- a/langs/ja_JP.yaml
+++ b/langs/ja_JP.yaml
@@ -254,6 +254,7 @@ dropbox:
   msg_delivered: --jp-- {author} Your message was delivered
   msg_not_delivered: --jp-- {author} Your message was **not** delivered Please try again, or contact a moderator
   msg_blank: --jp-- I didn't find any text content in the original message
+  attachment_fail: --jp-- Attachment from {author} failed. Censored or deleted by member?
   msg_receipt: --jp-- Here's a copy of the dropbox message you sent in {channel}
   receipt_set_true: --jp-- receipt set. authors will be DMed a copy of their message in {channel}.
   receipt_set_false: --jp-- receipt set. authors won't be DMed for their messages in {channel}.

--- a/langs/ja_JP.yaml
+++ b/langs/ja_JP.yaml
@@ -251,9 +251,9 @@ dropbox:
   override_confirmation: --jp-- The channel {source} already delivers messages to {old_target}; do you want to change the target to {new_target}?
   msg_delivered: --jp-- Your message was delivered, {author}
   msg_not_delivered: --jp-- Your message was **not** delivered, {author}. Please try again, or contact a moderator
-  msg_receipt: Here's a copy of the dropbox message you sent in {channel}
-  receipt_set_true: receipt set. authors will be DM'd a copy of their message in {channel}.
-  receipt_set_false: receipt set. authors won't be dmed for their messages in {channel}.
+  msg_receipt: --jp-- Here's a copy of the dropbox message you sent in {channel}
+  receipt_set_true: --jp-- receipt set. authors will be DMed a copy of their message in {channel}.
+  receipt_set_false: --jp-- receipt set. authors won't be DMed for their messages in {channel}.
 autoresponder:
   mod_action_header: --jp-- Moderator actions
   mod_action_warning: --jp-- Moderator action flag will be ignored if response channel is not set. Use `!autoresponder setchannel`

--- a/langs/ja_JP.yaml
+++ b/langs/ja_JP.yaml
@@ -251,6 +251,9 @@ dropbox:
   override_confirmation: --jp-- The channel {source} already delivers messages to {old_target}; do you want to change the target to {new_target}?
   msg_delivered: --jp-- Your message was delivered, {author}
   msg_not_delivered: --jp-- Your message was **not** delivered, {author}. Please try again, or contact a moderator
+  msg_receipt: Here's a copy of the dropbox message you sent in {channel}
+  receipt_set_true: receipt set. authors will be DM'd a copy of their message in {channel}.
+  receipt_set_false: receipt set. authors won't be dmed for their messages in {channel}.
 autoresponder:
   mod_action_header: --jp-- Moderator actions
   mod_action_warning: --jp-- Moderator action flag will be ignored if response channel is not set. Use `!autoresponder setchannel`

--- a/utils/Database.py
+++ b/utils/Database.py
@@ -244,6 +244,7 @@ class DropboxChannel(Model):
     sourcechannelid = BigIntegerField()
     targetchannelid = BigIntegerField(default=0)
     deletedelayms = SmallIntegerField(default=0)
+    sendreceipt = BooleanField(default=False)
 
     class Meta:
         database = connection


### PR DESCRIPTION
New things:
* Added an option to turn receipts on and off per dropbox, and receipt tells the sender if Skybot was able to deliver their message or not and a copy of the message. which covers what was requested in issue #102.
 * The command `dropbox set_receipt <source_channel> <receipt_setting>` is for setting receipts on or off. It needs the id of the channel the dropbox is listening in and if receipts should be on or off for this dropbox. Result of calling this is that receipts are set on/off as specified. The `dropbox` command will also show the new setting per dropbox.
 * The message delivered into dropbox reports if receipts succeeded. An extra field is added that just says sent/failed, and only shows up on messages delivered when receipts were on.
 
Design:
The handling of a new message in source channels is broken into three sections: deliver, delete and dm. Operations are separated out in this order to make the process clearer and to get the message out of the channel as quickly as possible. Sending receipts wasn't important to do before removing message. Message content needed for receipt is saved in bot memory as pages before deleting, and only the names of attachments are saved for receipt. Since the messages are delivered first before receipts sent, the update on receipt status on the delivered message needs to be edited in.
 
Works better with issue #107 resolved. If not resolved, then receipts for dropbox messages with just an image will look a bit weird. The message will not have content and pagination returns one page that is empty. Receipt will try to put that in a code block but since content ins empty, it shows up as six backticks.

